### PR TITLE
Issue autodetect file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Adding tasks is very simple. You can have your tasks in three formats:
 Therefore, adding tasks to your project is as simple as this command:
 
 ```bash
-    pbs add_tasks --tasks-file tasks_file.json --tasks-type=json
+    pbs add_tasks --tasks-file tasks_file.json
 ```
 
 If you want to see all the available

--- a/helpers.py
+++ b/helpers.py
@@ -40,6 +40,7 @@ __all__ = ['find_app_by_short_name', 'check_api_error',
            '_delete_tasks', 'enable_auto_throttling',
            '_update_tasks_redundancy']
 
+
 def _create_project(config):
     """Create a project in a PyBossa server."""
     try:
@@ -116,7 +117,7 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
         # Check if for the data we have to auto-throttle task creation
         sleep, msg = enable_auto_throttling(data)
         # If true, warn user
-        if sleep: # pragma: no cover
+        if sleep:  # pragma: no cover
             click.secho(msg, fg='yellow')
         # Show progress bar
         with click.progressbar(data, label="Adding Tasks") as pgbar:
@@ -128,10 +129,10 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
                                                        priority_0=priority)
                 check_api_error(response)
                 # If auto-throttling enabled, sleep for 3 seconds
-                if sleep: # pragma: no cover
+                if sleep:  # pragma: no cover
                     time.sleep(3)
             return ("%s tasks added to project: %s" % (len(data),
-                                                  config.project['short_name']))
+                    config.project['short_name']))
     except exceptions.ConnectionError:
         return ("Connection Error! The server %s is not responding" % config.server)
     except (ProjectNotFound, TaskNotFound):
@@ -186,7 +187,7 @@ def _update_tasks_redundancy(config, task_id, redundancy, limit=300, offset=0):
             # Check if for the data we have to auto-throttle task update
             sleep, msg = enable_auto_throttling(tasks)
             # If true, warn user
-            if sleep: # pragma: no cover
+            if sleep:  # pragma: no cover
                 click.secho(msg, fg='yellow')
             with click.progressbar(tasks, label="Updating Tasks") as pgbar:
                 while len(tasks) > 0:
@@ -195,7 +196,7 @@ def _update_tasks_redundancy(config, task_id, redundancy, limit=300, offset=0):
                         response = config.pbclient.update_task(t)
                         check_api_error(response)
                         # If auto-throttling enabled, sleep for 3 seconds
-                        if sleep: # pragma: no cover
+                        if sleep:  # pragma: no cover
                             time.sleep(3)
                     offset += limit
                     tasks = config.pbclient.get_tasks(project.id, limit, offset)
@@ -258,6 +259,7 @@ def enable_auto_throttling(data, limit=299):
         return (True, msg)
     else:
         return False, None
+
 
 def format_json_task(task_info):
     """Format task_info into JSON if applicable."""

--- a/helpers.py
+++ b/helpers.py
@@ -84,6 +84,8 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
         project = find_app_by_short_name(config.project['short_name'],
                                          config.pbclient)
         tasks = tasks_file.read()
+        if tasks_type is None:
+            tasks_type = tasks_file.name.split('.')[-1]
         # Data list to process
         data = []
         # JSON type

--- a/helpers.py
+++ b/helpers.py
@@ -111,7 +111,8 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
                     tmp = dict(var_id=var_id, string=string)
                     data.append(tmp)
         else:
-            return ("Unknown format for the tasks file. Use json, csv or po.")
+            return ("Unknown format for the tasks file. Use json, csv, po or "
+                    "properties.")
         # Check if for the data we have to auto-throttle task creation
         sleep, msg = enable_auto_throttling(data)
         # If true, warn user

--- a/pbs.py
+++ b/pbs.py
@@ -137,7 +137,7 @@ def update_project(config, task_presenter, long_description, tutorial): # pragma
 @click.option('--tasks-file', help='File with tasks',
               default='project.tasks', type=click.File('r'))
 @click.option('--tasks-type', help='Tasks type: JSON|CSV|PO|PROPERTIES',
-              default='json', type=click.Choice(['json', 'csv', 'po',
+              default=None, type=click.Choice(['json', 'csv', 'po',
                                                  'properties']))
 @click.option('--priority', help="Priority for the tasks.", default=0)
 @click.option('--redundancy', help="Redundancy for tasks.", default=30)

--- a/test/default.py
+++ b/test/default.py
@@ -1,6 +1,5 @@
 """Test module for pbs client."""
 from mock import MagicMock
-import pbclient
 
 
 class TestDefault(object):
@@ -24,7 +23,6 @@ class TestDefault(object):
     config = MagicMock()
     config.server = 'http://server'
     config.api_key = 'apikey'
-    config.pbclient = pbclient
     config.project = {'name': 'name',
                       'description': 'description',
                       'short_name': 'short_name'}

--- a/test/test_pbs_add_tasks.py
+++ b/test/test_pbs_add_tasks.py
@@ -151,7 +151,8 @@ class TestPbsAddTask(TestDefault):
         pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, None, 0, 30)
-        assert res == "Unknown format for the tasks file. Use json, csv or po.", res
+        assert res == ("Unknown format for the tasks file. Use json, csv, po or "
+                      "properties."), res
 
     @patch('helpers.find_app_by_short_name')
     def test_add_tasks_unknow_type(self, find_mock):
@@ -171,7 +172,8 @@ class TestPbsAddTask(TestDefault):
         pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, 'doc', 0, 30)
-        assert res == "Unknown format for the tasks file. Use json, csv or po.", res
+        assert res == ("Unknown format for the tasks file. Use json, csv, po or "
+                      "properties."), res
 
     @patch('helpers.find_app_by_short_name')
     def test_add_tasks_csv_connection_error(self, find_mock):

--- a/test/test_pbs_add_tasks.py
+++ b/test/test_pbs_add_tasks.py
@@ -31,6 +31,27 @@ class TestPbsAddTask(TestDefault):
         assert res == '1 tasks added to project: short_name', res
 
     @patch('helpers.find_app_by_short_name')
+    def test_add_tasks_json_from_filextension(self, find_mock):
+        """Test add_tasks json without specifying file extension works."""
+        project = MagicMock()
+        project.name = 'name'
+        project.short_name = 'short_name'
+        project.description = 'description'
+        project.info = dict()
+
+        find_mock.return_value = project
+
+        tasks = MagicMock()
+        tasks.name = 'tasks.json'
+        tasks.read.return_value = json.dumps([{'info': {'key': 'value'}}])
+
+        pbclient = MagicMock()
+        pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
+        self.config.pbclient = pbclient
+        res = _add_tasks(self.config, tasks, None, 0, 30)
+        assert res == '1 tasks added to project: short_name', res
+
+    @patch('helpers.find_app_by_short_name')
     def test_add_tasks_csv_with_info(self, find_mock):
         """Test add_tasks csv with info field works."""
         project = MagicMock()
@@ -48,6 +69,27 @@ class TestPbsAddTask(TestDefault):
         pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, 'csv', 0, 30)
+        assert res == '1 tasks added to project: short_name', res
+
+    @patch('helpers.find_app_by_short_name')
+    def test_add_tasks_csv_from_filextension(self, find_mock):
+        """Test add_tasks csv without specifying file extension works."""
+        project = MagicMock()
+        project.name = 'name'
+        project.short_name = 'short_name'
+        project.description = 'description'
+        project.info = dict()
+
+        find_mock.return_value = project
+
+        tasks = MagicMock()
+        tasks.name = 'tasks.csv'
+        tasks.read.return_value = "info, value\n, %s, 2" % json.dumps({'key':'value'})
+
+        pbclient = MagicMock()
+        pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
+        self.config.pbclient = pbclient
+        res = _add_tasks(self.config, tasks, None, 0, 30)
         assert res == '1 tasks added to project: short_name', res
 
     @patch('helpers.find_app_by_short_name')
@@ -91,6 +133,27 @@ class TestPbsAddTask(TestDefault):
         assert res == '1 tasks added to project: short_name', res
 
     @patch('helpers.find_app_by_short_name')
+    def test_add_tasks_unknow_type_from_filextension(self, find_mock):
+        """Test add_tasks with unknown type from file extension works."""
+        project = MagicMock()
+        project.name = 'name'
+        project.short_name = 'short_name'
+        project.description = 'description'
+        project.info = dict()
+
+        find_mock.return_value = project
+
+        tasks = MagicMock()
+        tasks.name = 'tasks.doc'
+        tasks.read.return_value = "key, value\n, 1, 2"
+
+        pbclient = MagicMock()
+        pbclient.create_task.return_value = {'id': 1, 'info': {'key': 'value'}}
+        self.config.pbclient = pbclient
+        res = _add_tasks(self.config, tasks, None, 0, 30)
+        assert res == "Unknown format for the tasks file. Use json, csv or po.", res
+
+    @patch('helpers.find_app_by_short_name')
     def test_add_tasks_unknow_type(self, find_mock):
         """Test add_tasks with unknown type works."""
         project = MagicMock()
@@ -109,7 +172,6 @@ class TestPbsAddTask(TestDefault):
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, 'doc', 0, 30)
         assert res == "Unknown format for the tasks file. Use json, csv or po.", res
-
 
     @patch('helpers.find_app_by_short_name')
     def test_add_tasks_csv_connection_error(self, find_mock):
@@ -151,7 +213,6 @@ class TestPbsAddTask(TestDefault):
         res = _add_tasks(self.config, tasks, 'json', 0, 30)
         assert res == "Connection Error! The server http://server is not responding", res
 
-
     @patch('helpers.find_app_by_short_name')
     def test_add_tasks_another_error(self, find_mock):
         """Test add_tasks another error works."""
@@ -190,7 +251,6 @@ class TestPbsAddTask(TestDefault):
         po.untranslated_entries.return_value = [entry]
         po_mock.return_value = po
 
-
         tasks = MagicMock()
         tasks.read.return_value = json.dumps([{'info': {'msgid': 'English',
                                                         'msgtr':''}}])
@@ -200,6 +260,36 @@ class TestPbsAddTask(TestDefault):
                                                                'msgtr': ''}}
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, 'po', 0, 30)
+        assert res == '1 tasks added to project: short_name', res
+
+    @patch('polib.pofile')
+    @patch('helpers.find_app_by_short_name')
+    def test_add_tasks_po_from_filextension(self, find_mock, po_mock):
+        """Test add_tasks po without specifying file extension works."""
+        project = MagicMock()
+        project.name = 'name'
+        project.short_name = 'short_name'
+        project.description = 'description'
+        project.info = dict()
+        find_mock.return_value = project
+
+        entry = MagicMock()
+        entry.msgid = 'English'
+        entry.msgtr = ''
+        po = MagicMock()
+        po.untranslated_entries.return_value = [entry]
+        po_mock.return_value = po
+
+        tasks = MagicMock()
+        tasks.name = 'tasks.po'
+        tasks.read.return_value = json.dumps([{'info': {'msgid': 'English',
+                                                        'msgtr':''}}])
+
+        pbclient = MagicMock()
+        pbclient.create_task.return_value = {'id': 1, 'info': {'msgid': 'English',
+                                                               'msgtr': ''}}
+        self.config.pbclient = pbclient
+        res = _add_tasks(self.config, tasks, None, 0, 30)
         assert res == '1 tasks added to project: short_name', res
 
     @patch('helpers.find_app_by_short_name')
@@ -220,4 +310,25 @@ class TestPbsAddTask(TestDefault):
                                                                'string': ' foo'}}
         self.config.pbclient = pbclient
         res = _add_tasks(self.config, tasks, 'properties', 0, 30)
+        assert res == '1 tasks added to project: short_name', res
+
+    @patch('helpers.find_app_by_short_name')
+    def test_add_tasks_properties_from_filextension(self, find_mock):
+        """Test add_tasks properties without specifying file extension works."""
+        project = MagicMock()
+        project.name = 'name'
+        project.short_name = 'short_name'
+        project.description = 'description'
+        project.info = dict()
+        find_mock.return_value = project
+
+        tasks = MagicMock()
+        tasks.name = 'tasks.properties'
+        tasks.read.return_value = "foo_id= foo\n"
+
+        pbclient = MagicMock()
+        pbclient.create_task.return_value = {'id': 1, 'info': {'var_id': 'foo_id',
+                                                               'string': ' foo'}}
+        self.config.pbclient = pbclient
+        res = _add_tasks(self.config, tasks, None, 0, 30)
         assert res == '1 tasks added to project: short_name', res

--- a/test/test_pbs_add_tasks.py
+++ b/test/test_pbs_add_tasks.py
@@ -1,4 +1,3 @@
-import pbclient
 import json
 from helpers import *
 from default import TestDefault

--- a/test/test_pbs_add_tasks.py
+++ b/test/test_pbs_add_tasks.py
@@ -72,7 +72,7 @@ class TestPbsAddTask(TestDefault):
 
     @patch('helpers.find_app_by_short_name')
     def test_add_tasks_csv_without_info(self, find_mock):
-        """Test add_tasks csv with info field works."""
+        """Test add_tasks csv without info field works."""
         project = MagicMock()
         project.name = 'name'
         project.short_name = 'short_name'


### PR DESCRIPTION
Makes the command line option --tasks-type optional, as the type will be inferred from the filename extension. However, the option has not been removed for backwards compatibility.